### PR TITLE
1 add docker image build to release workflow

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -1,0 +1,16 @@
+name: On push, deploying to Test
+
+on: [push]
+
+jobs:
+  run-build-and-deploy:
+    uses: octopusden/octopus-base/.github/workflows/common-py-build-deploy.yml@main
+    with:
+      process_env: Test
+    secrets: inherit
+
+  build-push-docker-image:
+    uses: octopusden/octopus-base/.github/workflows/common-docker-build-deploy.yml@main
+    with:
+      tags: |
+        ghcr.io/${{ github.repository }}:${{ github.ref_name }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -1,0 +1,20 @@
+name: On Release, deploying to Prod
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  run-build-and-deploy:
+    uses: octopusden/octopus-base/.github/workflows/common-py-build-deploy.yml@main
+    with:
+      process_env: Prod
+    secrets: inherit
+
+  build-push-docker-image:
+    uses: octopusden/octopus-base/.github/workflows/common-docker-build-deploy.yml@main
+    with:
+      tags: |
+        ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+        ghcr.io/${{ github.repository }}:latest
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,27 @@
-ARG PYTHON_VERSION=3.7
-FROM python:${PYTHON_VERSION}
+FROM debian:bullseye
 
 USER root
-RUN apt-get --quiet --assume-yes update && apt-get --quiet --assume-yes install sqlite3 curl
+
+# "psycopg2" will not be installed correctly without 'libpq-dev' and 'build-essential'
+
+RUN apt-get --quiet --assume-yes update && \
+    apt-get --no-install-recommends --quiet --assume-yes install \
+        python3-pysvn \
+        python3-pip \
+        python3-dev \
+        libpq-dev \
+        build-essential \
+        libmagic1 \
+        curl && \
+    python3 -m pip install --upgrade pip && \
+    python3 -m pip install --upgrade setuptools wheel
+
 RUN rm -rf /build
 COPY --chown=root:root . /build
 WORKDIR /build
-RUN python -m pip install $(pwd) && python -m unittest discover -v && python setup.py bdist_wheel
+RUN python3 -m pip install $(pwd) && \
+    python3 -m unittest discover -v && \
+    python3 setup.py bdist_wheel
 
 HEALTHCHECK --interval=1m --timeout=30s --start-period=15s --retries=3 \
      CMD curl -v --silent http://localhost:5400/clients 2>&1 | grep '< HTTP/1.1 200 OK'

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ RUN python3 -m pip install $(pwd) && \
 HEALTHCHECK --interval=1m --timeout=30s --start-period=15s --retries=3 \
      CMD curl -v --silent http://localhost:5400/clients 2>&1 | grep '< HTTP/1.1 200 OK'
 
-ENTRYPOINT ["python", "-m", "gunicorn", "oc_client_provider.wsgi:app", "-b", "0.0.0.0:5400"]
+ENTRYPOINT ["python3", "-m", "gunicorn", "oc_client_provider.wsgi:app", "-b", "0.0.0.0:5400"]
 

--- a/Readme.md
+++ b/Readme.md
@@ -4,14 +4,15 @@
 
 #### Required
 
-    - *PSQL\_URL*
-    - *PSQL\_USER*
-    - *PSQL\_PASSWORD*
+- *PSQL\_URL*
+- *PSQL\_USER*
+- *PSQL\_PASSWORD*
 
 #### Optional
-    - *DJANGO\_TIMEZONE* default: **Etc/UTC**
-    - *COUNTERPARTY\_ENABLED* default: **False**
-    - *COUNTERPARTY\_PATH* default: `client_counterparties.yml` in current working directory
+
+- *DJANGO\_TIMEZONE* default: **Etc/UTC**
+- *COUNTERPARTY\_ENABLED* default: **False**
+- *COUNTERPARTY\_PATH* default: `client_counterparties.yml` in current working directory
 
 ## Client counterparty functionality
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "1.0.0"
+__version = "1.0.1"
 
 setup(name="oc-client-provider",
         version=__version,


### PR DESCRIPTION
- `Dockerfile` changed to build from `debian` because of binary dependencies which does not work correctly in `python` official images (based on that `debian` too).
- Actions to deploy *PyPI* packages and *Docker* images added.