### PR TITLE
Counterparty returns empty string always

### DIFF
--- a/oc_client_provider/app/client_counterparty.py
+++ b/oc_client_provider/app/client_counterparty.py
@@ -21,7 +21,7 @@ class ClientCounterparty(object):
         :param client_code: client code
         :return: client counterparty
         """
-        if not hasattr(self, "__counterparty_path") or not self.__counterparty_path:
+        if not hasattr(self, "_ClientCounterparty__counterparty_path") or not self.__counterparty_path:
             logging.debug("Counterparty is disabled, returning empty string")
             return ''
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-__version = "1.0.3"
+__version = "1.0.4"
 
 setup(name="oc-client-provider",
         version=__version,


### PR DESCRIPTION
The cause:
https://peps.python.org/pep-0008/#descriptive-naming-styles
```
__double_leading_underscore: when naming a class attribute, invokes name mangling (inside class FooBar, __boo becomes _FooBar__boo).
```